### PR TITLE
Handle delay after dovecot startup before stats are available

### DIFF
--- a/dovecot_exporter.go
+++ b/dovecot_exporter.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-        "errors"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -49,7 +48,7 @@ func CollectFromReader(file io.Reader, ch chan<- prometheus.Metric) error {
 	}
 	columnNames := strings.Fields(scanner.Text())
         if( columnNames[0] != "user" ) {
-          return errors.New( "No data yet");
+          return fmt.Errorf( "No data yet");
         }
 	columns := []*prometheus.Desc{}
 	for _, columnName := range columnNames[1:] {

--- a/dovecot_exporter.go
+++ b/dovecot_exporter.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+        "errors"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -47,6 +48,9 @@ func CollectFromReader(file io.Reader, ch chan<- prometheus.Metric) error {
 		return fmt.Errorf("Failed to extract columns from input")
 	}
 	columnNames := strings.Fields(scanner.Text())
+        if( columnNames[0] != "user" ) {
+          return errors.New( "No data yet");
+        }
 	columns := []*prometheus.Desc{}
 	for _, columnName := range columnNames[1:] {
 		columns = append(columns, prometheus.NewDesc(


### PR DESCRIPTION
I added in a proper handling of a call to the exporter if user stats are not available yet, so it doesn't break the exporter and causes a crash.