### PR TITLE
Update Alpine to 3.14

### DIFF
--- a/build_static.sh
+++ b/build_static.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-docker run -i -v `pwd`:/dovecot_exporter alpine:3.8 /bin/sh << 'EOF'
+docker run -i -v `pwd`:/dovecot_exporter alpine:3.14 /bin/sh << 'EOF'
 set -ex
 
 # Install prerequisites for the build process.
@@ -11,6 +11,7 @@ update-ca-certificates
 # Build the dovecot_exporter.
 cd /dovecot_exporter
 export GOPATH=/gopath
+export GO111MODULE=auto
 go get -d ./...
 go build --ldflags '-extldflags "-static"'
 strip dovecot_exporter


### PR DESCRIPTION
I've updated the Alpine version to 3.14

3.8 fails to pull go modules from gopkg.in/alecthomas/kingpin.v2, as the ca-certificates package in the 3.8 repository does not have the most up-to-date Let's Encrypt root certificate, which causes builds to fail.

Also added `export GO111MODULE=auto` to the build script, to resolve:

`+ cd /dovecot_exporter
+ export 'GOPATH=/gopath'
+ go get -d ./...
go: go.mod file not found in current directory or any parent directory; see 'go help modules'
`