### PR TITLE
Update alecthomas/kingpin package import

### DIFF
--- a/dovecot_exporter.go
+++ b/dovecot_exporter.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var dovecotUpDesc = prometheus.NewDesc(


### PR DESCRIPTION
- alecthomas/kingpin has recently changed where the package is hosted. 
- This has the consequence to make "go mod tidy" in dovecot_exporter to fail with error : 

```
#15 0.425 go: dovecot_exporter imports
#15 0.425 	gopkg.in/alecthomas/kingpin.v2: gopkg.in/alecthomas/kingpin.v2@v2.3.1: parsing go.mod:
#15 0.425 	module declares its path as: github.com/alecthomas/kingpin/v2
#15 0.425 	        but was required as: gopkg.in/alecthomas/kingpin.v2
```

- This PR fixes that issue and make dovecot_exporter buildable again