### PR TITLE
change kingpin source from gopkg.in to github.com

### DIFF
--- a/dovecot_exporter.go
+++ b/dovecot_exporter.go
@@ -24,9 +24,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 var dovecotUpDesc = prometheus.NewDesc(


### PR DESCRIPTION
This pull request updates the source of the kingpin library from `gopkg.in/alecthomas/kingpin.v2` to `github.com/alecthomas/kingpin/v2`.

When I tried to build the dovecot_exporter project, I encountered an issue where the build process failed with the following error message:
```
go: dovecot_exporter imports gopkg.in/alecthomas/kingpin.v2: gopkg.in/alecthomas/kingpin.v2@v2.3.2: parsing go.mod:
	module declares its path as: github.com/alecthomas/kingpin/v2
	        but was required as: gopkg.in/alecthomas/kingpin.v2
```


